### PR TITLE
Fix ImGui compilation issue by updating vcpkg baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,6 @@ jobs:
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11
-      with:
-        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
 
     - name: Configure CMake
       run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
+        vcpkgGitCommitId: '39922dbab0cafd7a7150d459c6a181c7dee5dfbe'
 
     - name: Configure CMake
       run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
 
     - name: Configure CMake
       run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "gambit",
   "version-string": "0.1.0",
+  "builtin-baseline": "39922dbab0cafd7a7150d459c6a181c7dee5dfbe",
   "dependencies": [
     "sdl2",
     "enet",
@@ -11,6 +12,9 @@
     "glm",
     "sdl2-image",
     "sdl2-mixer",
-    "imgui"
+    {
+      "name": "imgui",
+      "version>=": "1.91.5"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed ImGui compilation errors in CI by updating vcpkg baseline
- Added minimum version requirement for imgui (>=1.91.5) in vcpkg.json

## Changes
- Added `builtin-baseline` to vcpkg.json pointing to latest vcpkg commit
- Specified `"version>=": "1.91.5"` for imgui dependency

The backend files required ImGui 1.91.5+ for APIs like ImGuiKey_Oem102, ImGuiPlatformIO, and new mouse cursor types.

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)